### PR TITLE
Support other engines

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -12,6 +12,7 @@ export interface IVPCExistingOptions {
 export type IVPCOptions = IVPCExistingOptions | IVPCCreateOptions;
 
 export interface IPluginOptions {
+    engine: string;
     username: string;
     password: string;
     identifier?: string; // defaults to AuroraClusterID{stage}

--- a/src/resource/cluster.ts
+++ b/src/resource/cluster.ts
@@ -16,7 +16,7 @@ export class Cluster extends Resource<IPluginOptions> {
             [this.getName(NamePostFix.DATABASE_CLUSTER)]: {
                 "Type": "AWS::RDS::DBCluster",
                 "Properties": {
-                    "Engine": "aurora",
+                    "Engine": this.options.engine || "aurora",
                     "EngineMode": "serverless",
                     "DBClusterIdentifier": this.options.identifier || "AuroraClusterID" + this.stage,
                     "MasterUsername": this.options.username,


### PR DESCRIPTION
As of today, Aurora serverless supports 3 engines, "aurora" "aurora-mysql" "aurora-postgresql"